### PR TITLE
Add PostgreSQL serial types

### DIFF
--- a/spec/stch/sql/ddl_spec.clj
+++ b/spec/stch/sql/ddl_spec.clj
@@ -53,6 +53,22 @@
                  (create
                    (-> (table :users)
                        (double' :points))))))
+    (context "serial"
+      (it "small-serial"
+        (should= "CREATE TABLE users (id SMALLSERIAL)"
+                 (create
+                   (-> (table :users)
+                       (small-serial :id)))))
+      (it "serial"
+        (should= "CREATE TABLE users (id SERIAL)"
+                 (create
+                   (-> (table :users)
+                       (serial :id)))))
+      (it "big-serial"
+        (should= "CREATE TABLE users (id BIGSERIAL)"
+                 (create
+                   (-> (table :users)
+                       (big-serial :id))))))
     (context "string"
       (it "chr"
         (should= "CREATE TABLE users (countryCode CHAR(2))"
@@ -493,19 +509,3 @@
       (should= "RENAME DATABASE prod TO production"
                (rename-db (db :prod)
                           (db :production))))))
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/stch/sql/ddl.clj
+++ b/src/stch/sql/ddl.clj
@@ -189,6 +189,10 @@
 (deftypefn decimal "DECIMAL")
 (deftypefn float' "FLOAT")
 (deftypefn double' "DOUBLE")
+; PostgreSQL Serial
+(deftypefn small-serial "SMALLSERIAL")
+(deftypefn serial "SERIAL")
+(deftypefn big-serial "BIGSERIAL")
 ; String
 (deftypefn chr "CHAR")
 (def char' chr)
@@ -631,14 +635,3 @@
                 (or (column? x) (index? x))
                 (list x))]
     (update-in m [:columns+keys] into y)))
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Adds type functions to the DDL namespace for PostgreSQL's smallserial/serial/bigserial types, and corresponding tests.
