### PR TITLE
Exclude update from clojure.core

### DIFF
--- a/src/stch/sql.clj
+++ b/src/stch/sql.clj
@@ -1,6 +1,7 @@
 (ns stch.sql
   "SQL DSL for query and data manipulation language
   (DML). Supports a majority of MySQL's statements."
+  (:refer-clojure :exclude [update])
   (:require [stch.sql.types :as types]))
 
 (defmulti build-clause (fn [name & args]


### PR DESCRIPTION
The update function has been added in clojure.core and the name conflicts with the update function in stch.sql